### PR TITLE
Change edit url from facebook to socket dot tech docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/SocketDotTech/socket-v2-sdk-docs/tree/master/docs/",
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Currently if you will try to edit the docs from UI, it will send you to facebook docosuarus link. This is because by default url is set in docasuurus which needs to be changed.

In this PR - i have changed to socket dot tech docs url. 